### PR TITLE
Fix "not a directory" errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,15 +12,19 @@ var spawnSync = require('cross-spawn').sync;
 
 var backup = function(filename) {
   try {
-    fs.writeFileSync(path.join(cwd, filename, '.backup'), fs.readFileSync(path.join(cwd, filename)));
-    fs.unlinkSync(path.join(cwd, filename));
+    const originalPath = path.join(cwd, filename)
+    const backupPath = originalPath + '.backup'
+    fs.writeFileSync(backupPath, fs.readFileSync(originalPath));
+    fs.unlinkSync(originalPath);
   } catch (err) {}
 };
 
 var restore = function(filename) {
   try {
-    fs.writeFileSync(path.join(cwd, filename), fs.readFileSync(path.join(cwd, filename, '.backup')));
-    fs.unlinkSync(path.join(cwd, filename, '.backup'));
+    const originalPath = path.join(cwd, filename)
+    const backupPath = originalPath + '.backup'
+    fs.writeFileSync(originalPath, fs.readFileSync(backupPath));
+    fs.unlinkSync(backupPath);
   } catch (err) {}
 };
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ var backup = function(filename) {
     const originalPath = path.join(cwd, filename)
     const backupPath = originalPath + '.backup'
     fs.writeFileSync(backupPath, fs.readFileSync(originalPath));
-    fs.unlinkSync(originalPath);
   } catch (err) {}
 };
 


### PR DESCRIPTION
`path.join(cwd, filename, '.backup')` evaluates to the path `somedirectory/package.json/.backup`. That causes `fs.writeFileSync` to not write the file at all because it can't find the folder `somedirectory/package.json/`

I've changed the path so that it instead evaluates to `somedirectory/package.json.backup` which fixes the issue. The backup will be side by side the original