### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Even with npm 5 and yarn, **installing node modules can be a long and painful ta
 `npm install -g install-subset`
 
 ## Usage
-
-Add something like to your package.json:
+Add something like this to your package.json:
 ```
 "subsets": {
   "build": {
@@ -43,13 +42,24 @@ Add something like to your package.json:
       "eslint",
       "prettier"
     ]
+  },
+  "container": {
+    "exclude": [
+      "nativescript",
+      "serverless",
+      "ngrok"
+    ]
   }
 }
 ```
 
 In your terminal: `$ subset install test`
 
-This installs your normal dependencies, minus eslint and prettier.
+This installs all of your application `dependencies`, excluding eslint and prettier, which are listed under your `devDependencies`. 
+
+If you would like install-subset to consider all of the dependencies of your application when evaluating subsets...
+
+In your terminal: `$ subset install container --all`
 
 ## Case Study
 


### PR DESCRIPTION
Elaborated a bit on usage to make it more clear that by default install-subset is focused on devDependencies. And, how to utilize this fantastic tool for situations where you only want a subset of the application dependencies to be installed. In a docker container is a prime example, where I do not want nativescript and serverless installed as these are more specific to my machine or for purposes of deploying lambda functions via our CI/CD pipeline.