### PR TITLE
feat: install multiple subsets via command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,29 @@
 **You can exclude some npm dependencies with install-subset when you don't need them**.
 
 Consider:
+
 - A CI server for your builds: you may not need your linting or testing tools. With a busy or shared server, you can save precious time.
 - A data generation library you only need once.
 - Toolsets that only a certain team member needs or uses, depending on their job, IDE or preferences.
+- Developing an application out of a monorepo that only needs certain dependencies for certain environments. (e.g. Mobile, Web, Desktop, or a Docker container)
 
 Even with npm 5 and yarn, **installing node modules can be a long and painful task**. Sometimes you have to build a native bindings like node-sass or couchbase, and sometimes you just have 100,000 dependencies. You are at the mercy of:
-- your connection speed & latency
-- your computer's willingness to cooperate
-- the number of dependencies
-- the [disk space available](http://devhumor.com/content/uploads/images/August2017/node-modules.jpg)
-- your patience
+
+- Your connection speed & latency.
+- Your computer's willingness to cooperate.
+- The number of dependencies.
+- The [disk space available](http://devhumor.com/content/uploads/images/August2017/node-modules.jpg).
+- Your patience.
 
 ## Installation
 
 `npm install -g install-subset`
 
 ## Usage
-Add something like this to your package.json:
-```
+
+Add something like this to your package.json...
+
+```json
 "subsets": {
   "build": {
     "include": [
@@ -55,30 +60,34 @@ Add something like this to your package.json:
 
 In your terminal: `$ subset install test`
 
-This installs all of your application `dependencies`, excluding eslint and prettier, which are listed under your `devDependencies`. 
+This installs all of your application `dependencies`, excluding eslint and prettier, which are listed under your `devDependencies`.
 
 If you would like install-subset to consider all of the dependencies of your application when evaluating subsets...
 
 In your terminal: `$ subset install container --all`
+
+If you would like install-subset to consider multiple subsets...
+
+In your terminal: `$subset install test container`
 
 ## Case Study
 
 [fakeit](https://github.com/bentonam/fakeit) is an amazing fake data generation library with support for couchbase, complicated related data models, multiple export options and more. However, its dependency tree is large, and has a dependency on a native Couchbase binary. In an example React Native project, just excluding this one rarely used devDependency cuts install time by around 29 seconds. 
 
 Warm cache, yarn v1.5.1, fresh install, without `install-subset`
-```
-rm -rf node_modules && yarn
-...
-real    0m40.496s
-user    0m32.451s
-sys     0m11.309s
-```
+
+  rm -rf node_modules && yarn
+  ...
+  real    0m40.496s
+  user    0m32.451s
+  sys     0m11.309s
+
 
 Warm cache, yarn v1.5.1, fresh install  With `install-subset` excluding [fakeit](https://github.com/bentonam/fakeit)
-```
-rm -rf node_modules && subset install "development"
-...
-real    0m11.157s
-user    0m9.261s
-sys     0m6.134s
-```
+
+  rm -rf node_modules && subset install "development"
+  ...
+  real    0m11.157s
+  user    0m9.261s
+  sys     0m6.134s
+

--- a/index.js
+++ b/index.js
@@ -42,14 +42,15 @@ var pick = function(obj, props) {
 cli
   .command('install <input_strings...>')
   .alias('i')
-  .option('-d, --clean', 'remove node_modules first')
-  .option('--npm', 'use npm to install')
-  .option('-a, --all', 'prune dependencies as well as devDependencies')
-  .description('install a given subset defined in package.json')
+  .option('-d, --clean', 'Remove node_modules first.')
+  .option('--npm', 'Use npm to install.')
+  .option('-a, --all', 'Prune dependencies as well as devDependencies.')
+  .description('Install a given subset or multiple subsets defined in package.json.')
   .action(function(input_strings, options) {
 
     if (!packageJson.subsets) {
-      throw 'No install subsets in package.json';
+      console.error('No install subsets in package.json.')
+      process.exit(1)
     }
 
     const subsetStrings = new Array()
@@ -64,7 +65,8 @@ cli
     for(var i=0; i < subsetStrings.length; i++) {
       const packageSubset = packageJson.subsets[subsetStrings[i]]
       if (!packageSubset) {
-        throw 'No install subset with name ' + subsetStrings[i];
+        console.error('No install subset with name ' + subsetStrings[i] + ' was found.')
+        process.exit(1)
       }
       if (packageSubset.exclude) {
         if (!subset.exclude) {
@@ -86,7 +88,8 @@ cli
     } else if (subset.exclude) {
       packageJson.devDependencies = omit(packageJson.devDependencies, subset.exclude);
     } else {
-      throw 'No valid subset actions found';
+      console.error('No valid subset actions found.')
+      process.exit(1)
     }
 
     if (options.all) {
@@ -96,7 +99,8 @@ cli
       } else if (subset.exclude) {
         packageJson.dependencies = omit(packageJson.dependencies, subset.exclude);
       } else {
-        throw 'No valid subset actions found';
+        console.error('No valid subset actions found.')
+        process.exit(1)
       }
     }
 
@@ -127,11 +131,13 @@ cli
     restore('yarn.lock');
 
     if (installer.status !== 0) {
-      throw 'Error code ' + installer.status;
+
+      console.error('Error code ' + installer.status + '.')
+      process.exit(1)
     }
 
     for (let input_string of subsetStrings) {
-      console.log('Installation of subset "' + input_string + '" successful');
+      console.log('Installation of subset "' + input_string + '" successful.');
     }
   });
 
@@ -142,5 +148,6 @@ cli.version(installSubsetPackageJson.version).parse(process.argv);
 if (cli.args.length === 0) cli.help();
 
 process.on('uncaughtException', err => {
-  console.log('ERROR: ' + err);
+  console.error('ERROR: ' + err);
+  process.exit(1)
 });

--- a/index.js
+++ b/index.js
@@ -40,22 +40,26 @@ var pick = function(obj, props) {
 };
 
 cli
-  .command('install [input_string]')
+  .command('install <input_strings...>')
   .alias('i')
   .option('-d, --clean', 'remove node_modules first')
   .option('--npm', 'use npm to install')
-  .option('-a, --all', 'prune dependencies as well as dev dependencies')
+  .option('-a, --all', 'prune dependencies as well as devDependencies')
   .description('install a given subset defined in package.json')
-  .action(function(input_string, options) {
-    if (!input_string) {
-      throw 'Please provide an install subset name';
-    }
+  .action(function(input_strings, options) {
 
     if (!packageJson.subsets) {
       throw 'No install subsets in package.json';
     }
 
-    const subsetStrings = input_string.split(" ")
+    const subsetStrings = new Array()
+
+    if (input_strings.length >= 1) {
+        for (let string of input_strings) {
+          subsetStrings.push(string)
+        }
+    }
+
     let subset = {}
     for(var i=0; i < subsetStrings.length; i++) {
       const packageSubset = packageJson.subsets[subsetStrings[i]]
@@ -126,7 +130,9 @@ cli
       throw 'Error code ' + installer.status;
     }
 
-    console.log('Installation of subset "' + input_string + '" successful');
+    for (let input_string of subsetStrings) {
+      console.log('Installation of subset "' + input_string + '" successful');
+    }
   });
 
 cli.command('*').action(() => cli.help());

--- a/index.js
+++ b/index.js
@@ -55,11 +55,26 @@ cli
       throw 'No install subsets in package.json';
     }
 
-    if (!packageJson.subsets[input_string]) {
-      throw 'No install subset with that name';
+    const subsetStrings = input_string.split(" ")
+    let subset = {}
+    for(var i=0; i < subsetStrings.length; i++) {
+      const packageSubset = packageJson.subsets[subsetStrings[i]]
+      if (!packageSubset) {
+        throw 'No install subset with name ' + subsetStrings[i];
+      }
+      if (packageSubset.exclude) {
+        if (!subset.exclude) {
+          subset.exclude = []
+        }
+        subset.exclude = [...subset.exclude, ...packageSubset.exclude]
+      }
+      if (packageSubset.include) {
+        if (!subset.include) {
+          subset.include = []
+        }
+        subset.include = [...subset.include, ...packageSubset.include]
+      }
     }
-
-    const subset = packageJson.subsets[input_string];
 
     // prune devDependencies according to subset declarations and options
     if (subset.include) {

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ cli
     }
 
     if (subset.include && subset.exclude) {
-        console.erro(`Failed to install subset ${input_string}.`);
+        console.error(`Failed to install subset ${input_string}.`);
         console.error("Subsets can only include OR exclude packages. Please correct your subset or combination of subsets and try again.")
         process.exit(1)
     }

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ cli
       process.exit(1)
     }
 
-    const subsetStrings = new Array()
+    const subsetStrings = []
 
     if (input_strings.length >= 1) {
         for (let string of input_strings) {
@@ -65,7 +65,7 @@ cli
     for(var i=0; i < subsetStrings.length; i++) {
       const packageSubset = packageJson.subsets[subsetStrings[i]]
       if (!packageSubset) {
-        console.error('No install subset with name ' + subsetStrings[i] + ' was found.')
+        console.error(`No install subset with name ${subsetStrings[i]} was found.`)
         process.exit(1)
       }
       if (packageSubset.exclude) {
@@ -80,6 +80,12 @@ cli
         }
         subset.include = [...subset.include, ...packageSubset.include]
       }
+    }
+
+    if (subset.include && subset.exclude) {
+        console.erro(`Failed to install subset ${input_string}.`);
+        console.error("Subsets can only include OR exclude packages. Please correct your subset or combination of subsets and try again.")
+        process.exit(1)
     }
 
     // prune devDependencies according to subset declarations and options
@@ -132,12 +138,12 @@ cli
 
     if (installer.status !== 0) {
 
-      console.error('Error code ' + installer.status + '.')
+      console.error(`Error code ${installer.status}.`)
       process.exit(1)
     }
 
     for (let input_string of subsetStrings) {
-      console.log('Installation of subset "' + input_string + '" successful.');
+      console.log(`Installation of subset ${input_string} successful.`);
     }
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -33,11 +33,11 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "requires": {
-        "nice-try": "1.0.4",
-        "path-key": "2.0.1",
-        "semver": "5.5.0",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "fs.realpath": {
@@ -50,12 +50,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "inflight": {
@@ -63,8 +63,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -87,7 +87,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "nice-try": {
@@ -100,7 +100,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -129,7 +129,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "^1.1.6"
       }
     },
     "resolve": {
@@ -137,7 +137,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "semver": {
@@ -150,7 +150,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -163,9 +163,9 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.0.4",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "which": {
@@ -173,7 +173,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wrappy": {


### PR DESCRIPTION
We love this module. And need it for our multi-platform environments. We found the need to be able to make it so "subset install input_string" could handle multiple input strings. Allowing one single invocation to process numerous subsets at once. We also made, what we feel, are some very small optimizations to the use of commander to handle this case. Updated the README to reflect these changes. And tested to make sure that this would not break other peoples current usage of the tool. 