### PR TITLE
Add repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,13 @@
     "subset",
     "dependency"
   ],
+  "bugs": {
+    "url": "https://github.com/tabrindle/install-subset/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tabrindle/install-subset.git"
+  },
   "author": "tabrindle@gmail.com",
   "license": "MIT",
   "prettier": {


### PR DESCRIPTION
Would enable this info on npm:
![image](https://user-images.githubusercontent.com/31949290/83863016-5be98e80-a740-11ea-95ea-20573e5875aa.png)
